### PR TITLE
Bugfix: `getPredictedTime` with no comparison

### DIFF
--- a/src/LiveSplitClient.js
+++ b/src/LiveSplitClient.js
@@ -265,7 +265,7 @@ class LiveSplitClient extends EventEmitter {
      * @returns {Promise} Command result or null on timeout.
      */
     getDelta(comparison = '') {
-        if (comparison.length > 0) comparison = ` ${comparison}`;
+        if (comparison) comparison = ` ${comparison}`;
         return this.send(`getdelta${comparison}`, true);
     }
     
@@ -299,16 +299,18 @@ class LiveSplitClient extends EventEmitter {
      * @returns {Promise} Command result or null on timeout.
      */
     getFinalTime(comparison = '') {
-        if (comparison.length > 0) comparison = ` ${comparison}`;
+        if (comparison) comparison = ` ${comparison}`;
         return this.send(`getfinaltime${comparison}`, true);
     }
     
     /**
      * Get predicted time
+     * @param {string} [comparison] - Comparison
      * @returns {Promise} Command result or null on timeout.
      */
-    getPredictedTime(comparison) {
-        return this.send(`getpredictedtime ${comparison}`, true);
+    getPredictedTime(comparison = '') {
+        if (comparison) comparison = ` ${comparison}`;
+        return this.send(`getpredictedtime${comparison}`, true);
     }
     
     /**


### PR DESCRIPTION
When using `getAll()`, `getPredictedTime()` will not be passed an
argument for the comparison, which causes it to send the message as
"getpredictedtime undefined", throwing an error in LiveSplit.Server.
This commit adds a catch for an undefined argument in
`getPredictedTime`. It will still throw an error in the current version
of LiveSplit.Server since it currently requires a parameter, but I have
a PR open that fixes this behavior in that component.

Additional changes:
 - Removed some superfluous conditions in `if` statements